### PR TITLE
make API URL change for participant state fetching

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,18 @@
 # Changelog
 
+## v1.1.3
+
+- change URL of fetching participant states, to keep the behaviour after the changes in management-api v1.4.0.
+
 ## v1.1.2
 
 - return results for `migrate_user` and `save_survey_to_study`
 - set encoding of the exported response in `get_response_csv`
 
 ## v1.1.1
- - Fix `get_survey_definition` url when no version is provided
- - remove duplicate lines
+
+- Fix `get_survey_definition` url when no version is provided
+- remove duplicate lines
 
 ## v1.1
 

--- a/influenzanet/api/management_api.py
+++ b/influenzanet/api/management_api.py
@@ -279,12 +279,12 @@ class ManagementAPIClient:
 
     def get_survey_definition(self, study_key, survey_key, version_id=''):
         """
-            Load a Survey definition 
+            Load a Survey definition
             If version_id is empty load the last published version (currents)
         """
         if self.auth_header is None:
             raise ValueError('need to login first')
-        url = self.management_api_url + '/v1/study/' + study_key + '/survey/' + survey_key 
+        url = self.management_api_url + '/v1/study/' + study_key + '/survey/' + survey_key
         if version_id != "":
             url += '/' + version_id
         r = requests.get(url, headers={'Authorization': 'Bearer ' + self.token})
@@ -348,7 +348,7 @@ class ManagementAPIClient:
     def get_participant_states(self, study_key: str, status:str=None):
         if self.auth_header is None:
             raise ValueError('need to login first')
-        url = "{}/v1/data/{}/participants".format(
+        url = "{}/v1/data/{}/participants/all".format(
                 self.management_api_url,
                 study_key,
             )


### PR DESCRIPTION
@cturbelin could you please make a new release for the python client? 
We are making changes to the API preparing it to be able to use with a graphical user interface, and in this particular case, it seemed simpler to use a dedicated URL to access all participants instead of the paginated data access. 